### PR TITLE
fix: workout_entry ID was not being scanned into entry

### DIFF
--- a/internal/store/workout_store.go
+++ b/internal/store/workout_store.go
@@ -59,7 +59,9 @@ func (pg *PostgresWorkoutStore) CreateWorkout(workout *Workout) (*Workout, error
 	}
 
 	// we also need to insert the entries
-	for _, entry := range workout.Entries {
+	for i := range workout.Entries {
+		// we scan the ID into `entry` (a *Workout) to make sure changes are persisted outside of the loop's scope
+		entry := &workout.Entries[i]
 		query := `
     INSERT INTO workout_entries (workout_id, exercise_name, sets, reps, duration_seconds, weight, notes, order_index)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)


### PR DESCRIPTION
Fixes #1

I was going through the course and was bugged by this bug.

If/when this is merged, I can also submit a correction on the course website so students get a note about it.